### PR TITLE
Add pidfile existense check to rhel init script for stopping daemon.

### DIFF
--- a/templates/redhat_mongod-init.conf.erb
+++ b/templates/redhat_mongod-init.conf.erb
@@ -55,7 +55,7 @@ stop()
   echo -n $"Stopping mongod_<%= mongod_instance %>: "
   killproc -p "$PIDFILE" -d 300 $mongod
   RETVAL=$?
-  rm "$PIDFILE"
+  [ -f "$PIDFILE" ] && rm "$PIDFILE"
   echo
   [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/mongod_<%= mongod_instance %>
 }

--- a/templates/redhat_mongos-init.conf.erb
+++ b/templates/redhat_mongos-init.conf.erb
@@ -43,7 +43,7 @@ stop()
   echo -n $"Stopping mongos_<%= mongos_instance %>: "
   killproc -p "$PIDFILE" -d 30 $mongos -TERM
   RETVAL=$?
-  rm "$PIDFILE"
+  [ -f "$PIDFILE" ] && rm "$PIDFILE"
   echo
 }
 


### PR DESCRIPTION
At least with my environment - RHEL6.4 -, killproc in /etc/init.d/functions removes pidfile.
