### PR TITLE
fixing variable name, and adding @ to clear up master warnings

### DIFF
--- a/templates/debian_mongod-init.conf.erb
+++ b/templates/debian_mongod-init.conf.erb
@@ -21,7 +21,7 @@
 # Suite 330, Boston, MA 02111-1307 USA
 #
 ### BEGIN INIT INFO
-# Provides:          mongod_<%= mongod_instance %>
+# Provides:          mongod_<%= @mongod_instance %>
 # Required-Start:    $network $local_fs $remote_fs
 # Required-Stop:     $network $local_fs $remote_fs
 # Should-Start:      $named

--- a/templates/debian_mongos-init.conf.erb
+++ b/templates/debian_mongos-init.conf.erb
@@ -21,7 +21,7 @@
 # Suite 330, Boston, MA 02111-1307 USA
 #
 ### BEGIN INIT INFO
-# Provides:          mongod_<%= mongod_instance %>
+# Provides:          mongod_<%= @mongos_instance %>
 # Required-Start:    $network $local_fs $remote_fs
 # Required-Stop:     $network $local_fs $remote_fs
 # Should-Start:      $named


### PR DESCRIPTION
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template mongodb/debian_mongos-init.conf.erb:
  Filepath: /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb
  Line: 81
  Detail: Could not find value for 'mongod_instance' at /etc/puppet/environments/development/modules/mongodb/templates/debian_mongos-init.conf.erb:24
 at /etc/puppet/environments/development/modules/mongodb/manifests/mongos.pp:22 on node mongoprototype1.dallas07.softlayer.georiot.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
