### PR TITLE
Reuse mongod lockfile as pidfile. Fixes "change from stopped to running failed" after initial install

### DIFF
--- a/templates/debian_mongod-init.conf.erb
+++ b/templates/debian_mongod-init.conf.erb
@@ -57,7 +57,7 @@ NAME=mongodb_<%= mongod_instance %>
 # http://docs.mongodb.org/manual/reference/configuration-options/
 CONF="/etc/mongod_<%= mongod_instance %>.conf"
 DBPATH=`awk -F= '/^dbpath=/{print $2}' "$CONF"`
-PIDFILE=`awk -F= '/^pidfilepath=/{print $2}' "$CONF"`
+PIDFILE=<%= scope.lookupvar('mongodb::params::dbdir') %>/mongod_<%= mongod_instance %>/mongod.lock
 ENABLE_MONGODB=yes
 
 # Handle NUMA access to CPUs (SERVER-3574)
@@ -122,8 +122,8 @@ start_server() {
   mkdir -p $DBPATH || exit 5
   chown -R ${DAEMONUSER}:${DAEMONGROUP} $DBPATH
 # Start the process using the wrapper
-            start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
-                        --make-pidfile --chuid $DAEMONUSER \
+            start-stop-daemon --background --start --quiet \
+                        --chuid $DAEMONUSER \
                         --exec $NUMACTL $DAEMON $DAEMON_DELIMITER $DAEMON_OPTS
             errcode=$?
 	return $errcode

--- a/templates/mongod.conf.erb
+++ b/templates/mongod.conf.erb
@@ -3,8 +3,6 @@
 
 dbpath=<%= scope.lookupvar('mongodb::params::dbdir') %>/mongod_<%= mongod_instance %>
 
-pidfilepath=<%= scope.lookupvar('mongodb::params::dbdir') %>/mongod_<%= mongod_instance %>/mongod.pid
-
 logpath=<%= scope.lookupvar('mongodb::params::logdir') %>/mongod_<%= mongod_instance %>.log
 
 logappend=<%= mongod_logappend %>


### PR DESCRIPTION
The module uses both mongodb's builtin pidfile writing mechanism (`--pidfilepath`) and start-stop-daemon's `--make-pidfile`, in addition to the pid already written to the mongo lockfile. This appears to result in an incorrect pid written to the pidfile during initial install (i.e. `puppet agent --test ...`)

This produces the following error (process is already running but we don't see it in `status` due to wrong pid, can't `start` again because lockfile exists):

```
Debug: /Stage[main]/Mongodb/File[/etc/init.d/mongodb]: The container Class[Mongodb] will propagate my refresh event
Debug: Class[Mongodb::Install]: The container Stage[main] will propagate my refresh event
Notice: /Stage[main]//Node[n10]/Mongodb::Mongod[test]/File[/etc/init.d/mongod_test]/ensure: defined content as '{md5}3cad35a4e47bcafa3c1d75f5f0fa1c87'
Debug: /Stage[main]//Node[n10]/Mongodb::Mongod[test]/File[/etc/init.d/mongod_test]: The container Mongodb::Mongod[test] will propagate my refresh event
Notice: /Stage[main]//Node[n10]/Mongodb::Mongod[test]/File[/etc/mongod_test.conf]/ensure: defined content as '{md5}e2ba8d5bfa72cb080deb1c40523b33f7'
Debug: /Stage[main]//Node[n10]/Mongodb::Mongod[test]/File[/etc/mongod_test.conf]: The container Mongodb::Mongod[test] will propagate my refresh event
Debug: Service[mongod_test](provider=upstart): Could not find mongod_test.conf in /etc/init
Debug: Service[mongod_test](provider=upstart): Could not find mongod_test.conf in /etc/init.d
Debug: Service[mongod_test](provider=upstart): Could not find mongod_test in /etc/init
Debug: Executing '/etc/init.d/mongod_test status'
Debug: Executing '/etc/init.d/mongod_test start'
Error: Could not start Service[mongod_test]: Execution of '/etc/init.d/mongod_test start' returned 1:
Error: /Stage[main]//Node[n10]/Mongodb::Mongod[test]/Service[mongod_test]/ensure: change from stopped to running failed: Could not start Service[mongod_test]: Execution of '/etc/init.d/mongod_craw ler_2 start' returned 1:
...
Debug: Class[Mongodb::Logrotate]: The container Stage[main] will propagate my refresh event
Notice: /Stage[main]/Mongodb/Anchor[mongodb::end]: Dependency Service[mongod_test] has failures: true
Warning: /Stage[main]/Mongodb/Anchor[mongodb::end]: Skipping because of failed dependencies
```

start/status/stop also will not work until the created process is killed manually

Why not just reuse the lockfile, which contains the pid, and avoid creating one with start-stop-daemon? This resolves this particular issue and is simpler in general.
