### PR TITLE
fix for puppet >3.3 - /etc/init.d/mongodb init script

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,11 +56,10 @@ class mongodb (
 
     file {
         "/etc/init.d/${::mongodb::params::old_servicename}":
-            ensure  => present,
+            ensure  => file,
             content => template("${module_name}/replacement_mongod-init.conf.erb"),
             require => Service[$::mongodb::params::old_servicename],
             mode    => '0755',
-            replace => true,
             before  => Anchor['mongodb::end'],
     }
 


### PR DESCRIPTION
fix for puppet >3.3, to ensure that the default init script is replaced, it now spits a warning of 'Warning: /Stage[main]/Mongodb/File[/etc/init.d/mongodb]: Ensure set to :present but file type is link so no content will be synced' under >3.3 otherwise, and this module blats out its own init scripts
