### PR TITLE
pidfile folder creation

### DIFF
--- a/templates/redhat_mongod-init.conf.erb
+++ b/templates/redhat_mongod-init.conf.erb
@@ -24,6 +24,7 @@ OPTIONS=" -f $CONFIGFILE"
 # for now.  This can go away when this script stops supporting 1.8.
 DBPATH=`awk -F= '/^dbpath=/{print $2}' "$CONFIGFILE"`
 PIDFILE=`awk -F= '/^pidfilepath=/{print $2}' "$CONFIGFILE"`
+PIDPATH=`dirname $PIDFILE`
 mongod=${MONGOD-/usr/bin/mongod}
 
 MONGO_USER=<%= scope.lookupvar('mongodb::run_as_user') %>
@@ -44,6 +45,11 @@ start()
   echo -n $"Starting mongod_<%= @mongod_instance %>: "
   mkdir -p $DBPATH || exit 5
   chown -R ${MONGO_USER}:${MONGO_GROUP} $DBPATH
+  if [ "$DBPATH" != "$PIDPATH" ]
+  then
+    mkdir -p $PIDPATH || exit 5
+    chown -R ${MONGO_USER}:${MONGO_GROUP} $PIDPATH
+  fi
   daemon --user $MONGO_USER $NUMACTL $mongod $OPTIONS
   RETVAL=$?
   echo

--- a/templates/redhat_mongos-init.conf.erb
+++ b/templates/redhat_mongos-init.conf.erb
@@ -22,7 +22,7 @@ OPTIONS=" -f $CONFIGFILE"
 # shuts down the correct running pid, but that's unavailable in 1.8
 # for now.  This can go away when this script stops supporting 1.8.
 PIDFILE=`awk -F= '/^pidfilepath=/{print $2}' "$CONFIGFILE"`
-DBPATH=`dirname $PIDFILE`
+PIDPATH=`dirname $PIDFILE`
 mongos=/usr/bin/mongos
 
 MONGO_USER=<%= scope.lookupvar('mongodb::run_as_user') %>
@@ -31,8 +31,8 @@ MONGO_GROUP=<%= scope.lookupvar('mongodb::run_as_group') %>
 start()
 {
   echo -n $"Starting mongos_<%= @mongos_instance %>: "
-  mkdir -p $DBPATH || exit 5
-  chown -R ${MONGO_USER}:${MONGO_GROUP} $DBPATH
+  mkdir -p $PIDPATH || exit 5
+  chown -R ${MONGO_USER}:${MONGO_GROUP} $PIDPATH
   daemon --user $MONGO_USER $mongos $OPTIONS
   RETVAL=$?
   echo


### PR DESCRIPTION
When configuring a custom pidfilepath on redhat the folder is not
created for mongod instances. This causes the pidfile to be created
in a different location (dbpath) and the service will be seen as
stopped by puppet. This problem is not present in mongos as it
sets DBPATH as the path of the pidfile. This change changes anyway
also mongos to be aligned with mongod pidfile path variable name.
