### PR TITLE
Fix init script for multiple mongo instances

### DIFF
--- a/templates/debian_mongod-init.conf.erb
+++ b/templates/debian_mongod-init.conf.erb
@@ -122,8 +122,8 @@ start_server() {
   mkdir -p $DBPATH || exit 5
   chown -R ${DAEMONUSER}:${DAEMONGROUP} $DBPATH
 # Start the process using the wrapper
-            start-stop-daemon --background --start --quiet \
-                        --chuid $DAEMONUSER \
+            start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
+                        --make-pidfile --chuid $DAEMONUSER \
                         --exec $NUMACTL $DAEMON $DAEMON_DELIMITER $DAEMON_OPTS
             errcode=$?
 	return $errcode


### PR DESCRIPTION
The issue is the following.

It is not possible to run multiple instances of the mongo process on the same host using startup script on debian. As an example, you cannot run a mongo (as replica node) if a mongo config server is already running, because both depends on /usr/bin/mongo but with different configuration.

Adding `--pidfile $PIDFILE` and `--make-pidfile` make it possible to run multiple mongo with startup script.
