### PR TITLE
Clean up config spacing

### DIFF
--- a/templates/mongod.conf.erb
+++ b/templates/mongod.conf.erb
@@ -2,31 +2,22 @@
 # mongod.conf
 
 dbpath=<%= scope.lookupvar('mongodb::dbdir') %>/mongod_<%= @mongod_instance %>
-
 pidfilepath=<%= scope.lookupvar('mongodb::pidfilepath') %>/mongod_<%= @mongod_instance %>/mongod.pid
-
 logpath=<%= scope.lookupvar('mongodb::logdir') %>/mongod_<%= @mongod_instance %>.log
-
 logappend=<%= @mongod_logappend %>
 
 rest=<%= @mongod_rest %>
-
 fork=<%= @mongod_fork %>
-
 <%- if @mongod_shardsvr != false -%>
 shardsvr=<%= @mongod_shardsvr %>
 <%- end -%>
-
 <%- if @mongod_configsvr != false -%>
 configsvr=<%= @mongod_configsvr %>
 <%- end -%>
-
 <%- if @mongod_bind_ip != "" -%>
 bind_ip=<%= @mongod_bind_ip %>
 <%- end -%>
-
 port=<%= @mongod_port %>
-
 <%- if @mongod_replSet != "" -%>
 replSet=<%= @mongod_replSet %>
 <%- end -%>
@@ -36,7 +27,6 @@ auth=<%= @mongod_auth %>
 <%- if @mongod_useauth != false -%>
 keyFile = /etc/mongod_<%= @mongod_instance %>.key
 <%- end -%>
-
 <%- @mongod_add_options.each do |addoption| -%>
 <%= addoption %>
 <%- end -%>

--- a/templates/mongos.conf.erb
+++ b/templates/mongos.conf.erb
@@ -2,25 +2,18 @@
 # mongos.conf
 
 pidfilepath=<%= scope.lookupvar('mongodb::pidfilepath') %>/mongos_<%= @mongos_instance %>/mongos.pid
-
 logpath=<%= scope.lookupvar('mongodb::logdir') %>/mongos_<%= @mongos_instance %>.log
-
 logappend=<%= @mongos_logappend %>
 
 fork = <%= @mongos_fork %>
-
-<% if @mongos_bind_ip != "" %>
+<%- if @mongos_bind_ip != "" -%>
 bind_ip=<%= @mongos_bind_ip %>
-<% end %>
-
+<%- end -%>
 port = <%= @mongos_port %>
-
 configdb = <%= @mongos_configServers %>
-
-<% @mongos_add_options.each do |addoption| %>
+<%- @mongos_add_options.each do |addoption| -%>
 <%= addoption %>
-<% end %>
-
-<% if @mongos_useauth != false -%>
+<%- end -%>
+<%- if @mongos_useauth != false -%>
 keyFile = /etc/mongos_<%= @mongos_instance %>.key
-<% end -%>
+<%- end -%>


### PR DESCRIPTION
The default erb template leaves a lot of empty newlines in it.  This is an attempt to clean that up.

Example:
Current formatting:

```
# !!! generated by puppet !!!
# mongod.conf

dbpath=/data/mongod_config

pidfilepath=/data/mongod_config/mongod.pid

logpath=/var/log/mongodb/mongod_config.log

logappend=true

rest=true

fork=true


configsvr=true


port=27018

```

New Formatting:

```
# !!! generated by puppet !!!
# mongod.conf

dbpath=/data/mongod_config
pidfilepath=/data/mongod_config/mongod.pid
logpath=/var/log/mongodb/mongod_config.log
logappend=true

rest=true
fork=true
configsvr=true
port=27018
```
