### PR TITLE
Ubuntu apt source location was wrong; Don't block logrotate if server is not running.

### DIFF
--- a/templates/logrotate.conf.erb
+++ b/templates/logrotate.conf.erb
@@ -15,8 +15,8 @@
 	create 0640 <%= scope.lookupvar('mongodb::run_as_user') -%> <%= scope.lookupvar('mongodb::run_as_group') %>
 	sharedscripts
 	postrotate
-		killall -SIGUSR1 mongod || true
-		killall -SIGUSR1 mongos || true
+		killall -SIGUSR1 mongod
+		killall -SIGUSR1 mongos
 		find <%= scope.lookupvar('mongodb::logdir') %> -type f -regex ".*\.\(log.[0-9].*-[0-9].*\)" -exec rm {} \;
 	endscript
 }


### PR DESCRIPTION
Two fixes.
- Ubuntu apt source location issue. See http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
- Logrotate should not be blocked when mongod or mongos is not running. It's common (for me) to run mongod without mongos (on db server) or mongos without mongod (on front end server).
