### PR TITLE
make installing 2.6.x possible using mongodb-org

### DIFF
--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -34,7 +34,12 @@ class mongodb::repos::apt (
       default  => 'http://downloads-distro.mongodb.org/repo/debian-sysvinit',
     }
 
-    $package_name = 'mongodb-10gen'
+    if ($mongodb::package_name == undef) {
+      $package_name = 'mongodb-10gen'
+    } else {
+      $package_name = $mongodb::package_name
+    }
+    
     $release = 'dist'
     $repos = '10gen'
   }


### PR DESCRIPTION
Hello! 

Currently the module will not be able to install the example in the readme for installing 2.6

```
 class { 'mongodb':
    package_name  => 'mongodb-org',
    package_ensure => '2.6.11',
    logdir       => '/var/log/mongodb/',
    # only debian like distros
         old_servicename => 'mongod'
  }
```

Problem is that mongodb-org ~= 2.6 is no longer available for the `http://repo.mongodb.org/apt/debian` repo but it is available for `http://downloads-distro.mongodb.org/repo/debian-sysvinit` 

This pull requires the package_name to be defined.
