### PR TITLE
set DBPATH and PIDFILE in startup scripts through puppet itself

### DIFF
--- a/templates/debian_mongod-init.conf.erb
+++ b/templates/debian_mongod-init.conf.erb
@@ -56,7 +56,7 @@ NAME=mongodb_<%= @mongod_instance %>
 # Other configuration options are located in $CONF file. See here for more:
 # http://docs.mongodb.org/manual/reference/configuration-options/
 CONF="/etc/mongod_<%= @mongod_instance %>.conf"
-DBPATH=`awk -F= '/^dbpath=/{print $2}' "$CONF"`
+DBPATH="<%= scope.lookupvar('mongodb::dbdir') %>/mongod_<%= @mongod_instance %>"
 PIDFILE=<%= scope.lookupvar('mongodb::pidfilepath') %>/mongod_<%= @mongod_instance %>/mongod.pid
 ENABLE_MONGODB=yes
 

--- a/templates/debian_mongos-init.conf.erb
+++ b/templates/debian_mongos-init.conf.erb
@@ -56,7 +56,7 @@ NAME=mongodb_<%= @mongos_instance %>
 # Other configuration options are located in $CONF file. See here for more:
 # http://docs.mongodb.org/manual/reference/configuration-options/
 CONF="/etc/mongos_<%= @mongos_instance %>.conf"
-PIDFILE=`awk -F= '/^pidfilepath=/{print $2}' "$CONF"`
+PIDFILE="<%= scope.lookupvar('mongodb::pidfilepath') %>/mongos_<%= @mongos_instance %>/mongos.pid"
 DBPATH=`dirname $PIDFILE`
 ENABLE_MONGODB=yes
 


### PR DESCRIPTION
by upgrading some hosts to puppet 3.0 I figured out, that the DBPATH and the PIDFILE in the startup scripts are catched up by awk and some shell calls. In my eyes, it would be much easier to get them also through puppet itself...