### PR TITLE
Update recommended ulimit settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ to install the mongodb packages.
 #####`ulimit_nofiles`
 
 Default is 64000 (integer). Number of allowed filehandles.
-See [recommendations](http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings)
+See [recommendations](https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings)
 
 #####`ulimit_nproc`
 
-Default is 32000 (integer).
-See [recommendations](http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings)
+Default is 64000 (integer).
+See [recommendations](https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings)
 
 #####`run_as_user`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,11 +47,11 @@ class mongodb::params {
 
     $logrotate_package_manage = true
 
-    # specify ulimit - nofile = 64000 and nproc = 32000 is recommended setting from
-    # http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+    # specify ulimit - nofile = 64000 and nproc = 64000 is recommended setting from
+    # https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 
     $ulimit_nofiles = 64000
-    $ulimit_nproc   = 32000
+    $ulimit_nproc   = 64000
 
     # specify pidfilepath
 


### PR DESCRIPTION
The current recommended nproc value has been increased from 32000 to 64000.
Fixed the URL to point to the current version.