### PR TITLE
Fixes osfamily case statement; issue #74

### DIFF
--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -16,8 +16,8 @@ define mongodb::mongos (
 # lint:ignore:selector_inside_resource  would not add much to readability
 
   $init_template = $::osfamily ? {
-    Debian => template('mongodb/debian_mongos-init.conf.erb'),
-    RedHat => template('mongodb/redhat_mongos-init.conf.erb'),
+    debian => template('mongodb/debian_mongos-init.conf.erb'),
+    redhat => template('mongodb/redhat_mongos-init.conf.erb'),
   }
 
   file {


### PR DESCRIPTION
Fixes #74 

Error in puppet output:

```
Error: Evaluation Error: No matching entry for selector parameter with value 'Debian' at /usr/src/puppet/modules/mongodb/manifests/mongos.pp:18:20 on node allinone01.watermelon.aws-us-w1.vc.i.kixeye.com
Error: Evaluation Error: No matching entry for selector parameter with value 'Debian' at /usr/src/puppet/modules/mongodb/manifests/mongos.pp:18:20 on node allinone01.watermelon.aws-us-w1.vc.i.kixeye.com
```