### PR TITLE
Fixes - Installation Issues

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,26 +33,25 @@ class mongodb (
     before  => Anchor['mongodb::end'],
   }
 
-  # stop and disable default mongod
-
-  service { $::mongodb::old_servicename:
-    ensure     => stopped,
-    enable     => false,
-    hasstatus  => true,
-    hasrestart => true,
-    subscribe  => Package['mongodb-package'],
-    before     => Anchor['mongodb::end'],
-  }
-
   # remove not wanted startup script, because it would kill all mongod
   # instances and not only the default mongod
 
   file { "/etc/init.d/${::mongodb::old_servicename}":
     ensure  => file,
     content => template("${module_name}/replacement_mongod-init.conf.erb"),
-    require => Service[$::mongodb::old_servicename],
     mode    => '0755',
     before  => Anchor['mongodb::end'],
+  }
+
+  # stop and disable default mongod
+  service { $::mongodb::old_servicename:
+    ensure     => stopped,
+    enable     => false,
+    hasstatus  => true,
+    hasrestart => true,
+    subscribe  => Package['mongodb-package'],
+    require    => File["/etc/init.d/${::mongodb::old_servicename}"],
+    before     => Anchor['mongodb::end'],
   }
 
   mongodb::limits::conf {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,10 +15,12 @@ class mongodb::install (
           Anchor['mongodb::install::begin'],
           Class[$::mongodb::params::repo_class]
         ]
+        $package_name = $::mongodb::apt::repos::package_name
     } else {
         $mongodb_10gen_package_require = [
           Anchor['mongodb::install::begin']
         ]
+        $package_name = $::mongodb::package_name
     }
 
     if ($package_version == undef ) {
@@ -39,7 +41,7 @@ class mongodb::install (
 
     package { 'mongodb-package':
         ensure  => $package_ensure,
-        name    => $::mongodb::repos::apt::package_name,
+        name    => $package_name,
         require => $mongodb_10gen_package_require,
         before  => [Anchor['mongodb::install::end']]
     }

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -16,8 +16,8 @@ define mongodb::mongos (
 # lint:ignore:selector_inside_resource  would not add much to readability
 
   $init_template = $::osfamily ? {
-    Debian => template('mongodb/debian_mongos-init.conf.erb'),
-    RedHat => template('mongodb/redhat_mongos-init.conf.erb'),
+    'debian' => template('mongodb/debian_mongos-init.conf.erb'),
+    'redhat' => template('mongodb/redhat_mongos-init.conf.erb'),
   }
 
   file {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class mongodb::params {
 
     # numbers of files (days) to keep by logrotate
 
-    $logrotatenumber = 7
+    $logrotatenumber = '7'
 
     # package version / installed / absent
 


### PR DESCRIPTION
Thanks @dwerder for your module. I would like to propose the following updates:

Changes:
- Fixes logrotate number - needs to be a string not an integer (weirdly the logrotate module itself has a message that looks like it should be an integer but an integer definetely does not work)
- Fix the stop and disable default mongod service in init.pp - this was failing on fresh installs of mongodb - especially later versions of mongodb where that /etc/init.d/mongodb isn't laid down by the package - I've left the putting down the dummy file but I've ordered it in a way where the file goes down first and then the service is stopped
- Fixup reference of $::mongodb::apt::repo::package_name - only reference this if repo_manage is true - otherwise reference $::mongodb::package_name 
