### PR TITLE
fix template filenames if $service_provider is "init"

### DIFF
--- a/manifests/mongod.pp
+++ b/manifests/mongod.pp
@@ -19,6 +19,7 @@ define mongodb::mongod (
 ) {
 
   $db_specific_dir = "${::mongodb::params::dbdir}/mongod_${mongod_instance}"
+  $osfamily_lc = downcase($::osfamily)
 
   file {
     "/etc/mongod_${mongod_instance}.conf":
@@ -56,7 +57,7 @@ define mongodb::mongod (
     $service_provider = 'init'
     file { "mongod_${mongod_instance}_service":
         path    => "/etc/init.d/mongod_${mongod_instance}",
-        content => template("mongodb/init.d/${::osfamily}_mongod.conf.erb"),
+        content => template("mongodb/init.d/${osfamily_lc}_mongod.conf.erb"),
         mode    => '0755',
         require => Class['mongodb::install'],
     }

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -14,6 +14,7 @@ define mongodb::mongos (
 ) {
 
   $db_specific_dir = "${::mongodb::params::dbdir}/mongos_${mongos_instance}"
+  $osfamily_lc = downcase($::osfamily)
 
   file {
     "/etc/mongos_${mongos_instance}.conf":
@@ -47,7 +48,7 @@ define mongodb::mongos (
     $service_provider = 'init'
     file { "mongos_${mongos_instance}_service":
         path    => "/etc/init.d/mongos_${mongos_instance}",
-        content => template("mongodb/init.d/${::osfamily}_mongos.conf.erb"),
+        content => template("mongodb/init.d/${osfamily_lc}_mongos.conf.erb"),
         mode    => '0755',
         require => Class['mongodb::install'],
     }


### PR DESCRIPTION
On systems where `$service_provider` is `init` the module is unable to locate the required templates:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER:
Server Error: Evaluation Error: Error while evaluating a Resource Statement,
Evaluation Error: Error while evaluating a Function Call,
Could not find template 'mongodb/init.d/Debian_mongod.conf.erb' at /etc/puppetlabs/code/environments/development/modules/mongodb/manifests/mongod.pp:59:20 at /etc/puppetlabs/code/environments/development/manifests/site.pp:20 on node XXX
```

The filenames are generated by using the `$osfamily` fact, where the first letter is uppercase (most of the time), but the templates are stored with lowercase letters.

My patch makes sure that a lowercase version of `$osfamily` is used.