### PR TITLE
custom value for $old_servicename ignored

### DIFF
--- a/manifests/mongod.pp
+++ b/manifests/mongod.pp
@@ -93,7 +93,7 @@ define mongodb::mongod (
         "/etc/mongod_${mongod_instance}.conf",
         "mongod_${mongod_instance}_service",
         $db_specific_dir],
-      Service[$::mongodb::params::old_servicename]],
+      Service[$::mongodb::old_servicename]],
     before     => Anchor['mongodb::end']
   }
 

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -84,7 +84,7 @@ define mongodb::mongos (
           "/etc/mongos_${mongos_instance}.conf",
           "mongos_${mongos_instance}_service",
           $db_specific_dir],
-        Service[$::mongodb::params::old_servicename],
+        Service[$::mongodb::old_servicename],
         Start_detector['configservers']],
       before     => Anchor['mongodb::end']
     }


### PR DESCRIPTION
When specifying a custom value for `$old_servicename` like this...

```
  class { 'mongodb':
    old_servicename => 'mongod',
    repo_manage      => false,
  }

  # skipped shard definitions
```

...the value is ignored and (at least on Ubuntu 14.04) an error will occur:

```
Error: Could not retrieve catalog from remote server:
Error 500 on SERVER: Server Error:
Invalid relationship: Service[mongod_shard01] { require => Service[mongodb] }, because Service[mongodb] doesn't seem to be in the catalog
```

The fix is to not use `$::mongodb::params::old_servicename`, but instead use `$::mongodb::old_servicename`.