### PR TITLE
workaround for Ubuntu 14.04 (upstart)

### DIFF
--- a/manifests/mongod.pp
+++ b/manifests/mongod.pp
@@ -53,7 +53,13 @@ define mongodb::mongod (
       ]
     }
   } else {
-    $service_provider = 'init'
+    # Workaround for Ubuntu 14.04
+    if ( versioncmp($::operatingsystemmajrelease, '14.04') == 0 ) {
+      $service_provider = undef # let puppet decide
+    } else {
+      $service_provider = 'init'
+    }
+
     file { "mongod_${mongod_instance}_service":
         path    => "/etc/init.d/mongod_${mongod_instance}",
         content => template("mongodb/init.d/${::osfamily}_mongod.conf.erb"),

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -44,7 +44,13 @@ define mongodb::mongos (
       ]
     }
   } else {
-    $service_provider = 'init'
+    # Workaround for Ubuntu 14.04
+    if ( versioncmp($::operatingsystemmajrelease, '14.04') == 0 ) {
+      $service_provider = undef # let puppet decide
+    } else {
+      $service_provider = 'init'
+    }
+
     file { "mongos_${mongos_instance}_service":
         path    => "/etc/init.d/mongos_${mongos_instance}",
         content => template("mongodb/init.d/${::osfamily}_mongos.conf.erb"),


### PR DESCRIPTION
Currently the module will not work with Ubuntu 14.04:

```
Error: /Stage[main]/Main/Node[nosql01.mgmt.markt.de]/Mongodb::Mongod[mongod_shard01]/Service[mongod_shard01]: Provider init is not functional on this host
```

My patch introduces a small workaround to set `$service_provider` to `undef` on Ubuntu 14.04 (to let Puppet decide which service provider should be used).

FWIW, Ubuntu 14.04 is supported until 2019, so it's worthwhile to add support for it :)