### PR TITLE
fix OS detection for RHEL/CentOS 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class mongodb::params {
       $systemd_os = versioncmp($::operatingsystemmajrelease, '15.10') > 0
     }
     'RedHat': {
-      $systemd_os = versioncmp($::operatingsystemmajrelease, '7') > 0
+      $systemd_os = versioncmp($::operatingsystemmajrelease, '7') >= 0
     }
     default: { # deal with lint
       $systemd_os = false


### PR DESCRIPTION
`$systemd_os` should be set to `true` on RHEL/CentOS 7. My patch fixes the use of `versioncmp`:

>     1 if version a is greater than version b
>     0 if the versions are equal
>     -1 if version a is less than version b

Without this fix the module is not working:

> Error: /Stage[main]/Profile::Db::Mongodb/Mongodb::Mongod[mongod_config]/Service[mongod_shardproxy]: Provider init is not functional on this host
> Error: /Stage[main]/Profile::Db::Mongodb/Mongodb::Mongod[mongod_shard1]/Service[mongod_shard1]: Provider init is not functional on this host
