### PR TITLE
support new configdb syntax

### DIFF
--- a/lib/puppet/provider/start_detector/ruby.rb
+++ b/lib/puppet/provider/start_detector/ruby.rb
@@ -34,7 +34,13 @@ Puppet::Type.type(:start_detector).provide(:ruby) do
     servers_checked = Hash[servers.map{ |k| [k, false] }]
 
     Integer(resource[:timeout]).times do
-      servers.each do |server|
+      servers.each do |_server|
+        # support MongoDB 3.2+ syntax for configDB
+        rplset, server = _server.split("/")
+        if server.nil?
+          server = _server
+        end
+
         begin
           ip, port = server.split(":")
 


### PR DESCRIPTION
Starting with MongoDB 3.2 it is possible to specify a replica set in the `configDB` [option](https://docs.mongodb.com/manual/reference/configuration-options/#sharding.configDB):

```
sharding:
  configDB: <configReplSetName>/cfg1.example.net:27017, cfg2.example.net:27017,...
```
Without this patch the server connectivity test will fail.
Tested on MongoDB 3.4.3 (I have no older version available to test).