### PR TITLE
Engine select

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ Enable/Disable auth true/false (default: false)
 
 Keyfile contents. Your random string/false (default: false)
 
+#####`mongod_engine`
+
+Select the database engine (default: wiredTiger)
+
 #####`mongod_monit`
 
 Use monit monitoring for mongod instances (default: false)

--- a/manifests/mongod.pp
+++ b/manifests/mongod.pp
@@ -13,6 +13,7 @@ define mongodb::mongod (
   $mongod_fork                            = true,
   $mongod_auth                            = false,
   $mongod_useauth                         = false,
+  $mongod_engine                          = 'wiredTiger',
   $mongod_monit                           = false,
   $mongod_add_options                     = [],
   $mongod_deactivate_transparent_hugepage = false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class mongodb::params {
     case $::osfamily {
       'Debian': {
         $repo_class          = 'mongodb::repos::apt'
-        $mongodb_pkg_name    = 'mongodb-10gen'
+        $mongodb_pkg_name    = 'mongodb-org'
         $old_server_pkg_name = 'mongodb-stable'
         $old_servicename     = 'mongodb'
         $run_as_user         = 'mongodb'
@@ -34,7 +34,7 @@ class mongodb::params {
       }
       'RedHat': {
         $repo_class          = 'mongodb::repos::yum'
-        $mongodb_pkg_name    = 'mongo-10gen-server'
+        $mongodb_pkg_name    = 'mongo-org-server'
         $old_server_pkg_name = 'mongodb-server'
         $old_servicename     = 'mongod'
         $run_as_user         = 'mongod'

--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -40,7 +40,7 @@ class mongodb::repos::apt (
       default  => 'http://downloads-distro.mongodb.org/repo/debian-sysvinit',
     }
 
-    $package_name = 'mongodb-10gen'
+    $package_name = 'mongodb-org'
     $release = 'dist'
     $repos = '10gen'
   }

--- a/templates/mongod.conf.yaml.erb
+++ b/templates/mongod.conf.yaml.erb
@@ -30,7 +30,7 @@ security:
 
 storage:
    dbPath: <%= scope.lookupvar('mongodb::dbdir') %>/mongod_<%= @mongod_instance %>
-   engine: wiredTiger
+   engine: <%= @mongod_engine %>
 
 <%- if @mongod_replSet != "" -%>
 replication:


### PR DESCRIPTION
This makes it possible to select whether to use MMapV1 or WiredTiger.
Some programs (RocketChat's my example) really do not like the new engine.