### PR TITLE
option to disable "start_detector"

### DIFF
--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -10,7 +10,8 @@ define mongodb::mongos (
   $mongos_logappend      = true,
   $mongos_fork           = true,
   $mongos_useauth        = false,
-  $mongos_add_options    = []
+  $mongos_add_options    = [],
+  $mongos_start_detector = true
 ) {
 
   $db_specific_dir = "${::mongodb::params::dbdir}/mongos_${mongos_instance}"
@@ -61,12 +62,13 @@ define mongodb::mongos (
   }
 
   # wait for servers starting
-
-  start_detector { 'configservers':
-    ensure  => present,
-    timeout => 120,
-    servers => $mongos_configServers,
-    policy  => one
+  if $mongos_start_detector {
+    start_detector { 'configservers':
+      ensure  => present,
+      timeout => 120,
+      servers => $mongos_configServers,
+      policy  => one
+    }
   }
 
   if ($mongos_useauth != false) {


### PR DESCRIPTION
This operation is not immutable. The detector runs every puppet run:

```puppet
Notice: /Stage[main]/Mongodb::Mongos[mongos]/Start_detector[configservers]/ensure: created
```

I wrapped the detector into a condition so I can disable it in my setup.

@dwerder what's a purpose of start_detector? I don't see any reason why puppet should wait until config servers are available.