### PR TITLE
add operationProfiling options for YAML config

### DIFF
--- a/manifests/mongod.pp
+++ b/manifests/mongod.pp
@@ -15,6 +15,8 @@ define mongodb::mongod (
   $mongod_useauth                         = false,
   $mongod_engine                          = 'wiredTiger',
   $mongod_monit                           = false,
+  $mongod_operation_profiling_slowms      = '',
+  $mongod_operation_profiling_mode        = '',
   $mongod_add_options                     = [],
   $mongod_deactivate_transparent_hugepage = false,
 ) {

--- a/templates/mongod.conf.yaml.erb
+++ b/templates/mongod.conf.yaml.erb
@@ -46,6 +46,16 @@ sharding:
    clusterRole: <%= @mongod_configsvr %>
 <%- end -%>
 
+<%- if @mongod_operation_profiling_slowms != "" or @mongod_operation_profiling_mode != "" -%>
+operationProfiling:
+<%- if @mongod_operation_profiling_slowms != "" -%>
+   slowOpThresholdMs: <%= @mongod_operation_profiling_slowms %>
+<%- end -%>
+<%- if @mongod_operation_profiling_mode != "" -%>
+   mode: <%= @mongod_operation_profiling_mode %>
+<%- end -%>
+<%- end -%>
+
 <%- if !@mongod_add_options.empty? -%>
 setParameter:
 <%- @mongod_add_options.sort_by{|key, value| key}.each do |key,value| -%>


### PR DESCRIPTION
I added operationProfiling options for YAML configuration.

I don't like the '$mongod_add_options' option which does 2 different things in both config formats and does not work at all in YAML format. You should decide if you want to support both config formats.

My opinion is to drop the old "key = value" format or at least mark is as deprecated and slowly notify others by warning that it will be removed in future.